### PR TITLE
add basic routing and pages

### DIFF
--- a/app/html/app.js
+++ b/app/html/app.js
@@ -1,16 +1,15 @@
 const nest = require('depnest')
-const { h } = require('mutant')
-
 
 exports.gives = nest('app.html.app')
+
+exports.needs = nest({
+  'app.sync.goTo': 'first'
+})
 
 exports.create = (api) => {
   return nest('app.html.app', app)
 
   function app () {
-    return h('h1', 'Hello!')
-
-
+    return api.app.sync.goTo({ page: 'home' })
   }
 }
-

--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,12 @@
 module.exports = {
   html: {
     app: require('./html/app')
+  },
+  page: {
+    group: require('./page/group'),
+    home: require('./page/home')
+  },
+  sync: {
+    goTo: require('./sync/goTo')
   }
 }
-

--- a/app/page/group.js
+++ b/app/page/group.js
@@ -1,0 +1,25 @@
+const nest = require('depnest')
+const { h } = require('mutant')
+
+exports.gives = nest('app.page.group')
+
+exports.needs = nest({
+  'app.sync.goTo': 'first'
+})
+
+exports.create = (api) => {
+  return nest('app.page.group', group)
+
+  function group (location) {
+    // location here can be the root message of a group : { type: 'group', key }
+    // TODO show specific group index described by key
+
+    const { goTo } = api.app.sync
+
+    return h('div', [
+      h('h1', 'Group'),
+      h('a', { 'ev-click': () => goTo({ page: 'home' }) }, 'Home'),
+      h('p', `key: ${location.key}`)
+    ])
+  }
+}

--- a/app/page/home.js
+++ b/app/page/home.js
@@ -1,0 +1,23 @@
+const nest = require('depnest')
+const { h } = require('mutant')
+
+exports.gives = nest('app.page.home')
+
+exports.needs = nest({
+  'app.sync.goTo': 'first'
+})
+
+exports.create = (api) => {
+  return nest('app.page.home', home)
+
+  function home (location) {
+    // location here can expected to be: { page: 'home' }
+    const { goTo } = api.app.sync
+
+    return h('div', [
+      h('h1', 'Home'),
+      h('div', { 'ev-click': () => goTo({ page: 'home' }) }, 'Home'),
+      h('div', { 'ev-click': () => goTo({ type: 'group', key: '%sadlkjas;lkdjas' }) }, 'Group')
+    ])
+  }
+}

--- a/app/sync/goTo.js
+++ b/app/sync/goTo.js
@@ -1,0 +1,22 @@
+const nest = require('depnest')
+
+exports.gives = nest('app.sync.goTo')
+
+exports.needs = nest({
+  'router.sync.router': 'first'
+})
+
+exports.create = (api) => {
+  return nest('app.sync.goTo', goTo)
+
+  function goTo (location) {
+    console.log('goTo', location)
+    const newView = api.router.sync.router(location)
+
+    // TODO (mix) : change once history in place
+    const oldView = document.body.firstChild
+    oldView
+      ? document.body.replaceChild(newView, oldView)
+      : document.body.appendChild(newView)
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const ticktack = {
-  app: require('./app')
+  app: require('./app'),
+  router: require('./router')
 }
 
 module.exports = ticktack

--- a/main.js
+++ b/main.js
@@ -17,5 +17,6 @@ const sockets = combine(
 const api = entry(sockets, nest('app.html.app', 'first'))
 
 const app = api.app.html.app()
-document.body.appendChild(app)
 
+// TODO (mix) : once goTo/ router is swapping pages, attach the app to the page here
+// document.body.appendChild(app)

--- a/package-lock.json
+++ b/package-lock.json
@@ -992,9 +992,9 @@
       }
     },
     "patchcore": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/patchcore/-/patchcore-1.8.2.tgz",
-      "integrity": "sha1-9ajmXxqesof1bC1UTEtzzPNM4Xo=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/patchcore/-/patchcore-1.9.0.tgz",
+      "integrity": "sha512-d9bJ7oivSS9uLknOZxnpJMDWTGVSyLmUt38mOTrL0LD1YEAAmThhi+6i/+mPXhm6605DFbYzWtxBVmXQ2t2SjQ==",
       "requires": {
         "bulk-require": "1.0.1",
         "bulkify": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "depject": "^4.1.0",
     "depnest": "^1.3.0",
-    "patchcore": "^1.8.2",
+    "mutant": "^3.21.2",
+    "patchcore": "^1.9.0",
     "setimmediate": "^1.0.5"
   }
 }

--- a/router/index.js
+++ b/router/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  sync: {
+    routes: require('./sync/routes')
+  }
+}

--- a/router/sync/routes.js
+++ b/router/sync/routes.js
@@ -1,0 +1,22 @@
+const nest = require('depnest')
+
+exports.gives = nest('router.sync.routes')
+
+exports.needs = nest({
+  'app.page.home': 'first',
+  'app.page.group': 'first'
+})
+
+exports.create = (api) => {
+  return nest('router.sync.routes', (sofar = []) => {
+    const { home, group } = api.app.page
+
+    // route format: [ routeValidator, routeFunction ]
+    const routes = [
+      [ ({ page }) => page === 'home', home ],
+      [ ({ type }) => type === 'group', group ]
+    ]
+
+    return [...sofar, ...routes]
+  })
+}


### PR DESCRIPTION
@dominictarr this PR adds : 

## Routing

`app.sync.routes` - where you add routes for the app

`app.sync.goTo` - the very MVP function which you give `location` objects to to change the view. This uses the router to generate matching views, and just swaps the whole `document.body` out at the moment.

## Pages

`app.page.*` - I've added a couple of example pages. 
**Note** links aren't being caught by a global catcher at the moment. The router I've written expects objects (thought it will happily normalise ssb-refs or channels into objects - [see here](https://github.com/ssbc/patchcore/blob/master/router/sync/normalise.js#L8-L16)), so for some links like the home page I've put in a specific event handler.
