### PR TITLE
add link click handler

### DIFF
--- a/app/async/catch-link-click.js
+++ b/app/async/catch-link-click.js
@@ -1,0 +1,38 @@
+const nest = require('depnest')
+const Url = require('url')
+
+exports.gives = nest('app.async.catchLinkClick')
+
+exports.create = function (api) {
+  return nest('app.async.catchLinkClick', catchLinkClick)
+
+  function catchLinkClick (root, cb) {
+    root.addEventListener('click', (ev) => {
+      if (ev.target.tagName === 'INPUT' && ev.target.type === 'file') return
+      if (ev.defaultPrevented) return // TODO check this is in the right place
+      ev.preventDefault()
+      ev.stopPropagation()
+
+      var anchor = null
+      for (var n = ev.target; n.parentNode; n = n.parentNode) {
+        if (n.nodeName === 'A') {
+          anchor = n
+          break
+        }
+      }
+      if (!anchor) return true
+
+      const href = anchor.getAttribute('href')
+      if (!href) return
+
+      const url = Url.parse(href)
+      const opts = { 
+        isExternal: !!url.host
+      }
+
+      cb(href, opts)
+    })
+  }
+}
+
+

--- a/app/html/app.js
+++ b/app/html/app.js
@@ -1,10 +1,12 @@
 const nest = require('depnest')
 const values = require('lodash/values')
 const insertCss = require('insert-css')
+const openExternal = require('open-external')
 
 exports.gives = nest('app.html.app')
 
 exports.needs = nest({
+  'app.async.catchLinkClick': 'first',
   'history.sync.push': 'first',
   'history.obs.location': 'first',
   'history.obs.store': 'first',
@@ -18,6 +20,12 @@ exports.create = (api) => {
   function app () {
     const css = values(api.styles.css()).join('\n')
     insertCss(css)
+
+    api.app.async.catchLinkClick(document.body, (link, { isExternal }) => {
+      if (isExternal) return openExternal(link)
+
+      api.history.sync.push(link)
+    })
 
     api.history.obs.location()(render)
     api.history.sync.push({ page: 'home' })

--- a/app/html/nav.js
+++ b/app/html/nav.js
@@ -18,7 +18,8 @@ exports.create = (api) => {
       h('div', { 'ev-click': () => push({page: 'home'}) }, 'Home'),
       // h('div', { 'ev-click': () => push({type: 'group', key: '%sadlkjas;lkdjas'}) }, 'Group'),
       h('div', { 'ev-click': () => push({key: '%fXXZgQrwnj7F+Y19H0IXxNriuvPFoahvusih3UzpkfA=.sha256'}) }, 'Thread A'),
-      h('div', { 'ev-click': () => push({key: '%3cWZHeN6k03XpvDBxrxP5bGLsNByFLTvr/rKYFV4f+c=.sha256'}) }, 'Thread B')
+      h('div', { 'ev-click': () => push({key: '%3cWZHeN6k03XpvDBxrxP5bGLsNByFLTvr/rKYFV4f+c=.sha256'}) }, 'Thread B'),
+      h('a', { href: '%YRhFXmsAwipgyiwuHSP+EBr9fGjSqrMpWXUxgWcHxkM=.sha256' }, 'href link')
     ])
   }
 }

--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,7 @@
 module.exports = {
+  async: {
+    catchLinkClick: require('./async/catch-link-click'),
+  },
   html: {
     app: require('./html/app'),
     thread: require('./html/thread'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1002,6 +1002,11 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
+    "open-external": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/open-external/-/open-external-0.1.1.tgz",
+      "integrity": "sha1-GfrTVRhBp3TwY8Nxs5+ycXXKjS4="
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -1052,9 +1057,9 @@
       }
     },
     "patchcore": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/patchcore/-/patchcore-1.9.0.tgz",
-      "integrity": "sha512-d9bJ7oivSS9uLknOZxnpJMDWTGVSyLmUt38mOTrL0LD1YEAAmThhi+6i/+mPXhm6605DFbYzWtxBVmXQ2t2SjQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/patchcore/-/patchcore-1.9.1.tgz",
+      "integrity": "sha512-TLm96QXRvutu0nvYkpkpCqmlpAxHlVex6rbz6pXdTnne5AYkM1k/VaKX+30vYRQimWtqIpl1zuKb8Q34g2B3iw==",
       "requires": {
         "bulk-require": "1.0.1",
         "bulkify": "1.4.2",
@@ -1074,7 +1079,7 @@
         "simple-mime": "0.1.0",
         "sorted-array-functions": "1.0.0",
         "split-buffer": "1.0.0",
-        "ssb-client": "4.5.0",
+        "ssb-client": "4.5.1",
         "ssb-config": "2.2.0",
         "ssb-feed": "2.3.0",
         "ssb-keys": "7.0.10",
@@ -1216,6 +1221,16 @@
         "relative-url": "1.0.2",
         "ws": "1.1.4"
       }
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "quote-stream": {
       "version": "0.0.0",
@@ -1450,9 +1465,9 @@
       "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc="
     },
     "ssb-client": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.5.0.tgz",
-      "integrity": "sha1-oiXi20o6q0NmGyemRLODfPNsuRA=",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.5.1.tgz",
+      "integrity": "sha512-Kn4eoSl3ZuS4BteQAtRIFM52jsGJPar4NJHLjis5OFxV22pNub/JfZHC2FdJBTtkPWJIJZi0ullCsm/EQ1Xs7Q==",
       "requires": {
         "explain-error": "1.0.4",
         "multicb": "1.2.2",
@@ -1721,6 +1736,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "lodash": "^4.17.4",
     "micro-css": "^2.0.1",
     "mutant": "^3.21.2",
+    "open-external": "^0.1.1",
     "patch-history": "^1.0.0",
-    "patchcore": "^1.9.0",
+    "patchcore": "^1.9.1",
     "pull-stream": "^3.6.0",
     "read-directory": "^2.1.0",
-    "setimmediate": "^1.0.5"
+    "setimmediate": "^1.0.5",
+    "url": "^0.11.0"
   }
 }

--- a/styles/global.mcss
+++ b/styles/global.mcss
@@ -3,5 +3,14 @@ body {
   background-color: #fff
 
   margin: 0
+
+  (a) {
+    color: #1a95a9
+    text-decoration: none
+
+    :hover {
+      text-decoration: underline
+    }
+  }
 }
 


### PR DESCRIPTION
This PR adds: 

##  `<a href>` click catching

checks if the the href is an 'external' link and kicks it out if it is.

if it's not, pushes into the history, which then triggers the listening `render` function

Note that you can pass _ssb-ref like_ strings into the router and it [normalises these into location objects](https://github.com/ssbc/patchcore/blob/master/router/sync/normalise.js#L11-L15) before testing routes with it. (see example in code)