### PR TITLE
homescreen - box model + mcss work

### DIFF
--- a/app/html/thread.mcss
+++ b/app/html/thread.mcss
@@ -1,10 +1,4 @@
 Thread {
-  background-color: #f7f7f7
-  font-family: 'arial'
-  padding: 1rem
-
-  max-width: 1400px
-
   display: flex
   flex-direction: column
 
@@ -22,18 +16,8 @@ Thread {
         div.msg {
           $primaryColor
 
-          border-bottom-left-radius: .9rem
-          border-top-left-radius: .9rem
-        }
-        :first-child {
-          div.msg {
-            border-top-right-radius: .9rem
-          }
-        }
-        :last-child {
-          div.msg {
-            border-bottom-right-radius: .9rem
-          }
+          (a) { color: #4d3568 }
+          $roundLeft
         }
       }
     }
@@ -43,22 +27,10 @@ Thread {
     $chunk
 
     div.msgs {
-
       div.msg-row {
         div.msg {
           border: 1.5px #ddd solid
-          border-bottom-right-radius: .9rem
-          border-top-right-radius: .9rem
-        }
-        :first-child {
-          div.msg {
-            border-top-left-radius: .9rem
-          }
-        }
-        :last-child {
-          div.msg {
-            border-bottom-left-radius: .9rem
-          }
+          $roundRight
         }
       }
     }
@@ -84,6 +56,13 @@ $chunk {
     max-width: 80%
     div.msg-row {
       display: flex
+
+      :first-child {
+        div.msg { $roundTop }
+      }
+      :last-child {
+        div.msg { $roundBottom }
+      }
 
       div.msg {
         line-height: 1.2rem

--- a/app/html/thread.mcss
+++ b/app/html/thread.mcss
@@ -6,7 +6,7 @@ Thread {
     $chunk
 
     justify-content: space-between
-    
+
     div.avatar {
       visibility: hidden
     }
@@ -68,7 +68,7 @@ $chunk {
         line-height: 1.2rem
         background-color: #fff
         padding: 0 .7rem
-        margin-bottom: .1rem 
+        margin-bottom: .1rem
         border-radius: .3rem
       }
       div.msg-spacer {

--- a/app/page/home.js
+++ b/app/page/home.js
@@ -36,17 +36,18 @@ function firstLine (text) {
   if (hasBrokenLink(sample))
     sample = sample + line.substring(81).match(/[^\)]*\)/)[0]
 
-  return sample
+  const ellipsis = (sample.length < line.length) ? '...' : '' 
+  return sample + ellipsis
+}
 
-  function trimLeadingMentions (str) {
-    return str.replace(/^(\s*\[@[^\)]+\)\s*)*/, '')
-    // deletes any number of pattern " [@...)  " from start of line
-  }
+function trimLeadingMentions (str) {
+  return str.replace(/^(\s*\[@[^\)]+\)\s*)*/, '')
+  // deletes any number of pattern " [@...)  " from start of line
+}
 
-  function hasBrokenLink (str) {
-    return /\[[^\]]*\]\([^\)]*$/.test(str)
-    // matches "[name](start_of_link"
-  }
+function hasBrokenLink (str) {
+  return /\[[^\]]*\]\([^\)]*$/.test(str)
+  // matches "[name](start_of_link"
 }
 
 exports.create = (api) => {
@@ -139,7 +140,7 @@ exports.create = (api) => {
           threadGroup(
             threads,
             threads.private,
-            function (_, msg) 
+            function (_, msg) {
               // NB: msg passed in is actually a 'thread', but only care about root msg
               const myId = api.keys.sync.id()
 

--- a/app/page/home.mcss
+++ b/app/page/home.mcss
@@ -64,8 +64,8 @@ $homePageSection {
     text-align: center
     padding-bottom: .3rem
     width: 420px
-    border-bottom: 1px solid #aaa
     margin-top: 0
+    margin-bottom: .4rem
   }
 
   div.threads {
@@ -86,11 +86,11 @@ $homePageSection {
       }
 
       div.content {
-        flex-grow: .8
+        flex-grow: 1
         background: #fff
         padding: 1rem
         border: 1px solid #ddd
-        border-radius: 1rem
+        border-radius: 2px
 
         div.subject {
           font-size: 1.2rem

--- a/app/page/home.mcss
+++ b/app/page/home.mcss
@@ -1,17 +1,92 @@
 Page -home {
-  h1 {}
 
   div.container {
-    div.group {
-      div.threadLink {
-        div.recps {
-          img {
-            $smallAvatar
+    $primaryBackground
+
+    section.updates {
+      -directMessage {
+        $homePageSection
+      }
+
+      -channel {
+        $homePageSection
+
+        div.threads { 
+          div.thread {
+            div.context {
+              background: #fff
+              min-width: 8rem
+              padding: .1rem .3rem
+              border: 1px solid #ddd
+              border-radius: 2px
+            }
           }
         }
+      }
+
+      -group {
+        $homePageSection
       }
     }
   }
 }
 
+$homePageSection {
+  display: flex
+  flex-direction: column
+  align-items: center
+  margin-bottom: 1.5rem
 
+  h2 {
+    color: #888
+    font-size: 1rem
+    text-align: center
+    padding-bottom: .3rem
+    width: 420px
+    border-bottom: 1px solid #aaa
+    margin-top: 0
+  }
+
+  div.threads {
+    div.thread {
+      display: flex
+      align-items: center
+
+      margin-bottom: .5rem
+
+      div.context {
+        display: flex
+        margin-right: 1rem
+
+        img {
+          $smallAvatar
+          margin-right: .5rem
+        }
+      }
+
+      div.content {
+        flex-grow: .8
+        background: #fff
+        padding: 1rem
+        border: 1px solid #ddd
+        border-radius: 1rem
+
+        div.subject {
+          font-weight: 600
+          margin-bottom: .3rem
+
+          $smallMarkdown
+        }
+        div.reply {
+          display: flex
+          div.author { 
+            font-weight: 600
+            margin-right: .3rem
+          }
+
+          $smallMarkdown
+        }
+      }
+    }
+  }
+}

--- a/app/page/home.mcss
+++ b/app/page/home.mcss
@@ -4,14 +4,35 @@ Page -home {
     $primaryBackground
 
     section.updates {
+
       -directMessage {
         $homePageSection
+
+        div.threads {
+          div.thread {
+            div.content {
+              div.subject {
+                display: flex
+
+                div.recps {
+                  display: flex
+                  font-weight: 600
+                  margin-right: .4rem
+
+                  div.recp {
+                    margin-right: .4rem
+                  }
+                }
+              }
+            }
+          }
+        }
       }
 
       -channel {
         $homePageSection
 
-        div.threads { 
+        div.threads {
           div.thread {
             div.context {
               background: #fff
@@ -72,15 +93,17 @@ $homePageSection {
         border-radius: 1rem
 
         div.subject {
-          font-weight: 600
+          font-size: 1.2rem
           margin-bottom: .3rem
 
-          $smallMarkdown
+          $largeMarkdown
         }
         div.reply {
           display: flex
-          div.author { 
-            font-weight: 600
+          color: #444
+
+          div.replySymbol {
+            margin-left: .7rem
             margin-right: .3rem
           }
 

--- a/app/page/page.mcss
+++ b/app/page/page.mcss
@@ -3,5 +3,14 @@ Page {
     margin-left: 1rem
   }
 
+  div.Nav {}
+
+  div.container {
+    $primaryBackground
+    padding: 1rem
+
+    max-width: 1400px
+
+  }
 }
 

--- a/app/page/private.js
+++ b/app/page/private.js
@@ -19,7 +19,7 @@ exports.create = (api) => {
     return h('Page -private', [
       h('h1', 'Private message'),
       api.app.html.nav(),
-      thread
+      h('div.container', thread)
     ])
   }
 }

--- a/styles/mixins.js
+++ b/styles/mixins.js
@@ -19,6 +19,10 @@ $colorSubtle {
   color: #222
 }
 
+$primaryBackground {
+  background-color: #f7f7f7
+}
+
 $smallAvatar {
   width: 3rem
   height: 3rem
@@ -29,5 +33,34 @@ $largeAvatar {
   width: 6rem
   height: 6rem
   border-radius: 3rem
+}
+
+$smallMarkdown {
+  div.Markdown {
+    h1, h2, h3, h4, h5, h6, p { 
+      font-size: 1rem 
+       margin: 0
+    }
+  }
+}
+
+$roundLeft {
+  border-top-left-radius: .9rem
+  border-bottom-left-radius: .9rem
+}
+
+$roundRight {
+  border-top-right-radius: .9rem
+  border-bottom-right-radius: .9rem
+}
+
+$roundTop {
+  border-top-left-radius: .9rem
+  border-top-right-radius: .9rem
+}
+
+$roundBottom {
+  border-bottom-left-radius: .9rem
+  border-bottom-right-radius: .9rem
 }
 `

--- a/styles/mixins.js
+++ b/styles/mixins.js
@@ -37,9 +37,20 @@ $largeAvatar {
 
 $smallMarkdown {
   div.Markdown {
-    h1, h2, h3, h4, h5, h6, p { 
-      font-size: 1rem 
-       margin: 0
+    h1, h2, h3, h4, h5, h6, p {
+      font-size: 1rem
+      font-weight: 300
+      margin: 0
+    }
+  }
+}
+
+$largeMarkdown {
+  div.Markdown {
+    h1, h2, h3, h4, h5, h6, p {
+      font-size: 1.2rem
+      font-weight: 300
+      margin: 0
     }
   }
 }


### PR DESCRIPTION
This is a first pass on styling. It makes the interface functional and starts to surface questions about the design.

![selection_359](https://user-images.githubusercontent.com/2665886/29201108-83bdd9a0-7eaf-11e7-9d54-6a064197090c.png)

Adds:
- styling to the home screen
  - visual groupings
  - seperate **'context'** (channel, people in thead, group) from **'content'** (subject + reply)
- extends firstLine sampling so it doesn't break md links
  - printing split markdown (e.g.` "...here is that [youtube video](https://w"`  )  looks terrible : 
  - _this is a bit of a pain, and probably needs more work in future_

Note that the way the thread chunks are set up, you can't actually click links because of the click-handler at the moment