### PR TITLE
add placeholders for all pages, add new app.html.link helper

### DIFF
--- a/app/html/app.js
+++ b/app/html/app.js
@@ -28,7 +28,7 @@ exports.create = (api) => {
     })
 
     api.history.obs.location()(render)
-    api.history.sync.push({ page: 'home' })
+    api.history.sync.push({ page: 'settings' })
   }
 
   function render (location) {

--- a/app/html/link.js
+++ b/app/html/link.js
@@ -1,0 +1,17 @@
+const nest = require('depnest')
+const { h } = require('mutant')
+
+exports.gives = nest('app.html.link')
+
+exports.needs = nest({
+  'history.sync.push': 'first',
+})
+
+exports.create = (api) => {
+  return nest('app.html.link', (location, body) => {
+    return h('Link', { 
+      'ev-click': () => api.history.sync.push(location)
+    }, body)
+  })
+}
+

--- a/app/html/nav.js
+++ b/app/html/nav.js
@@ -4,6 +4,7 @@ const { h } = require('mutant')
 exports.gives = nest('app.html.nav')
 
 exports.needs = nest({
+  'app.html.link': 'first',
   'history.sync.push': 'first',
   'history.sync.back': 'first'
 })
@@ -13,13 +14,17 @@ exports.create = (api) => {
 
   function nav (id) {
     const { push, back } = api.history.sync
+
+    const goHome = () => push({page: 'home'})
+    // CHANGE THIS : zero history
+    const Link = api.app.html.link
+
     return h('Nav', [
       h('div.back', { 'ev-click': back }, '←'),
-      h('div', { 'ev-click': () => push({page: 'home'}) }, 'Home'),
-      // h('div', { 'ev-click': () => push({type: 'group', key: '%sadlkjas;lkdjas'}) }, 'Group'),
-      h('div', { 'ev-click': () => push({key: '%fXXZgQrwnj7F+Y19H0IXxNriuvPFoahvusih3UzpkfA=.sha256'}) }, 'Thread A'),
-      h('div', { 'ev-click': () => push({key: '%3cWZHeN6k03XpvDBxrxP5bGLsNByFLTvr/rKYFV4f+c=.sha256'}) }, 'Thread B'),
-      h('a', { href: '%YRhFXmsAwipgyiwuHSP+EBr9fGjSqrMpWXUxgWcHxkM=.sha256' }, 'href link')
+      h('div', { 'ev-click': goHome }, 'Home'),
+      Link({ page: 'settings' }, 'Settings'),
+      Link({ page: 'userFind' }, 'Find a User'),
+      h('a', { href: '%YRhFXmsAwipgyiwuHSP+EBr9fGjSqrMpWXUxgWcHxkM=.sha256' }, 'A Thread')
     ])
   }
 }

--- a/app/html/nav.mcss
+++ b/app/html/nav.mcss
@@ -4,7 +4,8 @@ Nav {
 
   margin: 0 0 1rem 1rem
 
-  div {
+  a, div {
+    color: #222
     margin-right: 1rem
 
     :hover {

--- a/app/index.js
+++ b/app/index.js
@@ -5,11 +5,19 @@ module.exports = {
   html: {
     app: require('./html/app'),
     thread: require('./html/thread'),
-    nav: require('./html/nav')
+    link: require('./html/link'),
+    nav: require('./html/nav'),
   },
   page: {
-    group: require('./page/group'),
+    error: require('./page/error'),
+    groupFind: require('./page/groupFind'),
+    groupIndex: require('./page/groupIndex'),
+    groupNew: require('./page/groupNew'),
+    groupShow: require('./page/groupShow'),
     home: require('./page/home'),
-    private: require('./page/private')
+    settings: require('./page/settings'),
+    userFind: require('./page/userFind'),
+    userShow: require('./page/userShow'),
+    threadShow: require('./page/threadShow'),
   }
 }

--- a/app/page/error.js
+++ b/app/page/error.js
@@ -1,0 +1,22 @@
+const nest = require('depnest')
+const { h } = require('mutant')
+
+exports.gives = nest('app.page.error')
+
+exports.needs = nest({
+  'app.html.nav': 'first'
+})
+
+exports.create = (api) => {
+  return nest('app.page.error', error)
+
+  function error (location) {
+
+    return h('Page -error', [
+      h('h1', 'Error'),
+      api.app.html.nav(),
+      "The route wasn't found of there was an error",
+      location.error
+    ])
+  }
+}

--- a/app/page/groupFind.js
+++ b/app/page/groupFind.js
@@ -1,0 +1,21 @@
+const nest = require('depnest')
+const { h } = require('mutant')
+
+exports.gives = nest('app.page.groupFind')
+
+exports.needs = nest({
+  'app.html.nav': 'first'
+})
+
+exports.create = (api) => {
+  return nest('app.page.groupFind', groupFind)
+
+  function groupFind (location) {
+
+    return h('Page -groupFind', [
+      h('h1', 'Group Find'),
+      api.app.html.nav(),
+      h('p', `key: ${location.key}`)
+    ])
+  }
+}

--- a/app/page/groupIndex.js
+++ b/app/page/groupIndex.js
@@ -1,0 +1,19 @@
+const nest = require('depnest')
+const { h } = require('mutant')
+
+exports.gives = nest('app.page.groupIndex')
+
+exports.needs = nest({
+  'app.html.nav': 'first'
+})
+
+exports.create = (api) => {
+  return nest('app.page.groupIndex', groupIndex)
+
+  function groupIndex (location) {
+    return h('Page -groupIndex', [
+      h('h1', 'Group Index'),
+      api.app.html.nav()
+    ])
+  }
+}

--- a/app/page/groupNew.js
+++ b/app/page/groupNew.js
@@ -1,0 +1,19 @@
+const nest = require('depnest')
+const { h } = require('mutant')
+
+exports.gives = nest('app.page.groupNew')
+
+exports.needs = nest({
+  'app.html.nav': 'first'
+})
+
+exports.create = (api) => {
+  return nest('app.page.groupNew', groupNew)
+
+  function groupNew (location) {
+    return h('Page -groupNew', [
+      h('h1', 'Group New'),
+      api.app.html.nav()
+    ])
+  }
+}

--- a/app/page/groupShow.js
+++ b/app/page/groupShow.js
@@ -1,21 +1,21 @@
 const nest = require('depnest')
 const { h } = require('mutant')
 
-exports.gives = nest('app.page.group')
+exports.gives = nest('app.page.groupShow')
 
 exports.needs = nest({
   'app.html.nav': 'first'
 })
 
 exports.create = (api) => {
-  return nest('app.page.group', group)
+  return nest('app.page.groupShow', groupShow)
 
-  function group (location) {
+  function groupShow (location) {
     // location here can be the root message of a group : { type: 'group', key }
     // TODO show specific group index described by key
 
-    return h('Page -group', [
-      h('h1', 'Group'),
+    return h('Page -groupShow', [
+      h('h1', 'Group Show'),
       api.app.html.nav(),
       h('p', `key: ${location.key}`)
     ])

--- a/app/page/home.js
+++ b/app/page/home.js
@@ -60,6 +60,7 @@ exports.create = (api) => {
 
     function subject (msg) {
       const { subject, text } = msg.value.content
+
       return api.message.html.markdown(firstLine(subject|| text))
     }
 

--- a/app/page/settings.js
+++ b/app/page/settings.js
@@ -1,0 +1,20 @@
+const nest = require('depnest')
+const { h } = require('mutant')
+
+exports.gives = nest('app.page.settings')
+
+exports.needs = nest({
+  'app.html.nav': 'first'
+})
+
+exports.create = (api) => {
+  return nest('app.page.settings', settings)
+
+  function settings (location) {
+
+    return h('Page -settings', [
+      h('h1', 'Settings'),
+      api.app.html.nav(),
+    ])
+  }
+}

--- a/app/page/threadShow.js
+++ b/app/page/threadShow.js
@@ -1,7 +1,7 @@
 const nest = require('depnest')
 const { h } = require('mutant')
 
-exports.gives = nest('app.page.private')
+exports.gives = nest('app.page.threadShow')
 
 exports.needs = nest({
   'app.html.nav': 'first',
@@ -9,14 +9,14 @@ exports.needs = nest({
 })
 
 exports.create = (api) => {
-  return nest('app.page.private', privatePage)
+  return nest('app.page.threadShow', threadShow)
 
-  function privatePage (location) {
+  function threadShow (location) {
     // location here can expected to be an ssb-message
 
     const thread = api.app.html.thread(location.key)
 
-    return h('Page -private', [
+    return h('Page -threadShow', [
       h('h1', 'Private message'),
       api.app.html.nav(),
       h('div.container', thread)

--- a/app/page/userFind.js
+++ b/app/page/userFind.js
@@ -1,0 +1,20 @@
+const nest = require('depnest')
+const { h } = require('mutant')
+
+exports.gives = nest('app.page.userFind')
+
+exports.needs = nest({
+  'app.html.nav': 'first'
+})
+
+exports.create = (api) => {
+  return nest('app.page.userFind', userFind)
+
+  function userFind (location) {
+
+    return h('Page -userFind', [
+      h('h1', 'Find a User'),
+      api.app.html.nav()
+    ])
+  }
+}

--- a/app/page/userShow.js
+++ b/app/page/userShow.js
@@ -1,0 +1,21 @@
+const nest = require('depnest')
+const { h } = require('mutant')
+
+exports.gives = nest('app.page.userShow')
+
+exports.needs = nest({
+  'app.html.nav': 'first'
+})
+
+exports.create = (api) => {
+  return nest('app.page.userShow', userShow)
+
+  function userShow (location) {
+
+    return h('Page -userShow', [
+      h('h1', 'User show'),
+      api.app.html.nav(),
+      h('p', `key: ${location.key}`)
+    ])
+  }
+}

--- a/router/sync/routes.js
+++ b/router/sync/routes.js
@@ -1,11 +1,18 @@
 const nest = require('depnest')
-const ref = require('ssb-ref')
+const { isMsg, isFeed } = require('ssb-ref')
 exports.gives = nest('router.sync.routes')
 
 exports.needs = nest({
+  'app.page.error': 'first',
   'app.page.home': 'first',
-  'app.page.group': 'first',
-  'app.page.private': 'first'
+  'app.page.settings': 'first',
+  'app.page.groupFind': 'first',
+  'app.page.groupIndex': 'first',
+  'app.page.groupNew': 'first',
+  'app.page.groupShow': 'first',
+  'app.page.userFind': 'first',
+  'app.page.userShow': 'first',
+  'app.page.threadShow': 'first'
 })
 
 exports.create = (api) => {
@@ -15,9 +22,24 @@ exports.create = (api) => {
  
     const routes = [
       [ location => location.page === 'home', pages.home ],
-      [ location => location.type === 'group', pages.group ],
-      [ location => location.page === 'channel', pages.channel ],
-      [ location => ref.isMsg(location.key), pages.private ]
+      [ location => location.page === 'settings', pages.settings ],
+
+      // Group pages
+      [ location => location.page === 'groupFind', pages.groupFind ],
+      [ location => location.page === 'groupIndex', pages.groupIndex ],
+      [ location => location.page === 'groupNew', pages.groupNew ],
+      [ location => location.type === 'groupShow' && isMsg(location.key), pages.groupShow ],
+
+      // User pages
+      [ location => location.page === 'userFind', pages.userFind ],
+      [ location => isFeed(location.feed), pages.userShow ],
+
+      // Thread pages
+      // QUESTION - should this be for private threads + group threads?
+      [ location => isMsg(location.key), pages.threadShow ],
+
+      // Error page
+      [ location => true, pages.error ]
     ]
 
     return [...routes, ...sofar]


### PR DESCRIPTION
Quick PR to add placeholders for all the pages + their routes.

I'm going to lunch + a meeting.
Will merge after I get back @dominictarr (unless you have any comments)

Main changes : 
- `app.html.link` - builds links for the router nicely
- `router.sync.routes` - adding all the new routes, including a **default error route** for locations not matching any route. Could use this for displaying errors too. 
- `app.html.app` - changed the default route to the settings page (because home is broken by some chess messages atm !)
- `app.html.nav` - added a couple of the pages in as links to test our
