### PR TITLE
Get messages referenced in a thread

### DIFF
--- a/app/page/home.js
+++ b/app/page/home.js
@@ -85,11 +85,11 @@ exports.create = (api) => {
         })
 
         function latestUpdate(thread) {
-          var m = thread.timestamp
+          var m = thread.timestamp || 0
           if(!thread.replies) return m
 
           for(var i = 0; i < thread.replies.length; i++)
-            m = Math.max(thread.replies[i].timestamp, m)
+            m = Math.max(thread.replies[i].timestamp||0, m)
           return m
         }
 

--- a/main.js
+++ b/main.js
@@ -23,13 +23,13 @@ const sockets = combine(
     styles: require('./styles'),
     state: require('./state/obs'),
   },
-//  require('patch-history'),
   require('patchcore')
 )
 
 const api = entry(sockets, nest('app.html.app', 'first'))
 
 document.body.appendChild(api.app.html.app())
+
 
 
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ssb-mentions": "^0.4.0",
     "ssb-private": "^0.1.2",
     "ssb-query": "^0.1.2",
-    "ssb-reduce-stream": "^1.0.1",
+    "ssb-reduce-stream": "^1.0.2",
     "ssb-ref": "^2.7.1",
     "ssb-ws": "^1.0.3",
     "suggest-box": "^2.2.3",


### PR DESCRIPTION
The main effect of this is to pull in old threads that where commented on recently.
sometimes this will retrieve messages twice, because it requests a message, then then it comes in the stream. to fix this, I think just slow down the get, for say half a second.