### PR TITLE
implement an auto connecting pub

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,13 +4,7 @@ const ssbKeys = require('ssb-keys')
 const Path = require('path')
 
 const appName = 'ssb' //'ticktack-ssb'
-const opts = process.env.ssb_appname== 'ssb' ? {} :{
-  port: 43750,
-  blobsPort: 43751,
-  ws: {
-    port: 43751
-  }
-}
+const opts = process.env.ssb_appname== 'ssb' ? {} : require('./default-config.json')
 
 exports.gives = nest('config.sync.load')
 exports.create = (api) => {
@@ -26,3 +20,4 @@ exports.create = (api) => {
     return config
   })
 }
+

--- a/default-config.json
+++ b/default-config.json
@@ -1,0 +1,9 @@
+{
+  "port": 43750,
+  "blobsPort": 43751,
+  "ws": { "port": 43751 },
+  "caps": {"shs": "ErgQF85hFQpUXp69IXtLW+nXDgFIOKKDOWFX/st2aWk="},
+  "autoinvite": "128.199.132.182:43750:@7xMrWP8708+LDvaJrRMRQJEixWYp4Oipa9ohqY7+NyQ=.ed25519~YC4ZnjHH8qzsyHe2sihW8WDlhxSUH33IthOi4EsldwQ="
+}
+
+

--- a/main.js
+++ b/main.js
@@ -28,21 +28,18 @@ const sockets = combine(
 
 const api = entry(sockets, nest({
     'app.html.app': 'first',
-    'invite.async.autofollow': 'first'
+    'invite.async.autofollow': 'first',
+    'config.sync.load': 'first'
 }))
 
 document.body.appendChild(api.app.html.app())
 
-api.invite.async.autofollow(
-  'wx.larpa.net:8008:@DTNmX+4SjsgZ7xyDh5xxmNtFqa6pWi5Qtw7cE8aR9TQ=.ed25519~YIRnryeLBhtBa2il9fCWDlAIFWR37Uh63Vep0L6tk6c=',
-  function (err, follows) {
-  console.log('autofollowed', err, follows);
-})
-
-
-
-
-
-
-
-
+var invite = api.config.sync.load().autoinvite
+if(invite)
+  api.invite.async.autofollow(
+   invite,
+    function (err, follows) {
+    console.log('autofollowed', err, follows);
+  })
+else
+  console.log('no invite')


### PR DESCRIPTION
this depends on a PR to patchcore, to add cap support. https://github.com/ssbc/patchcore/pull/30

![ticktack-pub](https://user-images.githubusercontent.com/259374/29451309-4bdba916-8456-11e7-9c2d-6ad4cf840204.png)

also, default configuration is moved into a json file (easy to copy to `~/.ticktack/config` if you are running this with a separate sbot. also remember plugins.
my `~/.ticktack/config` looks like:
```
{
  "plugins": {
    "ssb-private": true,
    "ssb-backlinks": true,
    "ssb-contacts": true,
    "ssb-about": true
  },
  "port": 43750,
  "blobsPort": 43751,
  "ws": { "port": 43751 },
  "caps": {"shs": "ErgQF85hFQpUXp69IXtLW+nXDgFIOKKDOWFX/st2aWk="},
  "autoinvite": "128.199.132.182:43750:@7xMrWP8708+LDvaJrRMRQJEixWYp4Oipa9ohqY7+NyQ=.ed25519~YC4ZnjHH8qzsyHe2sihW8WDlhxSUH33IthOi4EsldwQ="
}
```