### PR TITLE
fix duplicates and missing messages

### DIFF
--- a/app/page/home.js
+++ b/app/page/home.js
@@ -83,14 +83,18 @@ exports.create = (api) => {
           return m
         }
 
+        var o = {}
         function roots (r) {
-          return Object.keys(r || {}).map(function (k) {
-            return threads.roots[r[k]]
+          return Object.keys(r || {}).map(function (name) {
+            var id = r[name]
+            if(!o[id]) {
+              o[id] = true
+              return threads.roots[id]
+            }
           }).filter(function (e) {
             return e && e.value
           })
         }
-
 
         var groupedThreads = roots(threads.private)
           .concat(roots(threads.channels))
@@ -133,4 +137,15 @@ exports.create = (api) => {
     ])
   })
 }
+
+
+
+
+
+
+
+
+
+
+
 


### PR DESCRIPTION
duplicates was caused by some things matching more than on thread or group, fixed by filtering out roots that you've seen before.

missing private messages was causes by the root of the thread being quite old, and it being loaded out of order, and on that code path it wasn't getting decrypted.

both of those problems are fixed now.